### PR TITLE
Read multibyte integer after opaque token

### DIFF
--- a/pyActiveSync/utils/wbxml.py
+++ b/pyActiveSync/utils/wbxml.py
@@ -182,7 +182,7 @@ class wbxml_parser(object):
             elif byte is self.GlobalTokens.STR_I:
                 current_element.text = self.decode_string()
             elif byte is self.GlobalTokens.OPAQUE:
-                opq_len = self.decode_byte()
+                opq_len = self.decode_multibyte_integer()
                 opq_str = ""
                 if current_element.tag == "Mime":
                     opq_str = self.decode_string(opq_len)
@@ -248,8 +248,7 @@ class wbxml_parser(object):
             if last:
                 retarray.append( integer & 0x7f )
                 last = False
-            else:
-                retarray.append( ( integer & 0x7f ) | 0x80 )
+            else: retarray.append( ( integer & 0x7f ) | 0x80 )
             integer = integer >> 7
         retarray.reverse()
         return retarray


### PR DESCRIPTION
Please refer to the example code from microsoft. It should be multibyte int after opaque token. The pointer will now shift by a right amount of length and avoid reading wrong data.